### PR TITLE
Proactively flush console output in SimpleDashboard.

### DIFF
--- a/src/ekam/SimpleDashboard.cpp
+++ b/src/ekam/SimpleDashboard.cpp
@@ -75,6 +75,8 @@ void SimpleDashboard::TaskImpl::setState(TaskState state) {
       }
       outputText.clear();
     }
+
+    fflush(outputStream);
   }
 }
 


### PR DESCRIPTION
SimpleDashboard is used when stdout is not a tty. But we still want it to flush proactively so that people can tail the log file or whatever.