### PR TITLE
Update TypeScript dependency to latest version

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -27,7 +27,7 @@
         "vscode-languageserver": "^4.0.0"
     },
     "devDependencies": {
-        "typescript": "^2.0.3",
+        "typescript": "^3.8.3",
         "vscode": "^1.1.0",
         "@types/node": "^6.0.40",
         "vsce": "^1.51.0"


### PR DESCRIPTION
This resolves a `An accessor cannot be declared in an ambient context.` build error when executing vscode:prepublish. See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#class-field-mitigations