### PR TITLE
Fix #29

### DIFF
--- a/src/ekam/ekam.cpp
+++ b/src/ekam/ekam.cpp
@@ -444,7 +444,13 @@ OwnedPtr<Dashboard> getDashboard(int maxDisplayedLogLines) {
   //
   // See issue #29
   struct winsize windowSize;
-  ioctl(STDOUT_FILENO, TIOCGWINSZ, &windowSize);
+  if(ioctl(STDOUT_FILENO, TIOCGWINSZ, &windowSize) < 0) {
+    const char *msg = strerror(errno);
+    DEBUG_WARNING
+      << "Error querying terminal size: " << msg << "; "
+      << "falling back to simple output.";
+    return newOwned<SimpleDashboard>(stdout);
+  }
   if(windowSize.ws_row == 0 || windowSize.ws_col == 0) {
     DEBUG_WARNING
       << "Terminal size looks suspicious "


### PR DESCRIPTION
Per discussion on the issue, this is arguably Nix's fault, not ours, but
we should be robust enough that the build doesn't fail just because the
terminal is wonky.

---

I tested this in nix, and can confirm that it prints a warning about a 0 by 0 terminal, and then does simple output.