### PR TITLE
vscode extension: Use `@types/vscode` instead of the vscode postinstall step

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -19,7 +19,6 @@
     "scripts": {
         "vscode:prepublish": "tsc -p ./",
         "compile": "tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install",
         "package": "vsce package"
     },
     "dependencies": {
@@ -28,7 +27,7 @@
     },
     "devDependencies": {
         "typescript": "^3.8.3",
-        "vscode": "^1.1.0",
+        "@types/vscode": "^1.1.0",
         "@types/node": "^6.0.40",
         "vsce": "^1.51.0"
     },


### PR DESCRIPTION
The `vscode` package is deprecated in favor of `@types/vscode` (and `vscode-test`): https://code.visualstudio.com/updates/v1_36#_splitting-vscode-package-into-typesvscode-and-vscodetest

At some point recently the postinstall script we run stopped working also, breaking `npm install` inside this path. I think the extension still has some issues at the moment, but this at least allows `npm install`/`npm run package` to succeed.