### PR TITLE
Pin vscode extension to languageclient/server 6.x

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -23,8 +23,8 @@
         "package": "vsce package"
     },
     "dependencies": {
-        "vscode-languageclient": "^4.0.0",
-        "vscode-languageserver": "^4.0.0"
+        "vscode-languageclient": "6.x",
+        "vscode-languageserver": "6.x"
     },
     "devDependencies": {
         "typescript": "^3.8.3",


### PR DESCRIPTION
It appears that version 7+ of the vscode language client and server have
breaking changes to the API. When pinned to 6.x the extension builds and
works as usual.

---

It looks like 7 came out about a month ago. Here's a snippet from 7+ errors (occur during `npm run package`):

```
node_modules/vscode-languageclient/lib/common/linkedEditingRange.d.ts:6:129 - error TS2694: Namespace '"vscode"' has no exported member 'LinkedEditingRanges'.

6     (this: void, document: code.TextDocument, position: code.Position, token: code.CancellationToken): code.ProviderResult<code.LinkedEditingRanges>;
                                                                                                                                  ~~~~~~~~~~~~~~~~~~~

node_modules/vscode-languageclient/lib/common/linkedEditingRange.d.ts:14:201 - error TS2694: Namespace '"vscode"' has no exported member 'LinkedEditingRanges'.

14     provideLinkedEditingRange?: (this: void, document: code.TextDocument, position: code.Position, token: code.CancellationToken, next: ProvideLinkedEditingRangeSignature) => code.ProviderResult<code.Linke
dEditingRanges>;
                                                                                                                                                                                                           ~~~~~
~~~~~~~~~~~~~~

node_modules/vscode-languageclient/lib/common/linkedEditingRange.d.ts:16:164 - error TS2694: Namespace '"vscode"' has no exported member 'LinkedEditingRangeProvider'.

16 export declare class LinkedEditingFeature extends TextDocumentFeature<boolean | proto.LinkedEditingRangeOptions, proto.LinkedEditingRangeRegistrationOptions, code.LinkedEditingRangeProvider> {
                                                                                                                                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/vscode-languageclient/lib/common/linkedEditingRange.d.ts:20:118 - error TS2694: Namespace '"vscode"' has no exported member 'LinkedEditingRangeProvider'.

20     protected registerLanguageProvider(options: proto.LinkedEditingRangeRegistrationOptions): [code.Disposable, code.LinkedEditingRangeProvider];
                                                                                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/vscode-languageclient/lib/common/protocolConverter.d.ts:117:66 - error TS2694: Namespace '"vscode"' has no exported member 'SemanticTokensLegend'.

117     asSemanticTokensLegend(value: ls.SemanticTokensLegend): code.SemanticTokensLegend;
                                                                     ~~~~~~~~~~~~~~~~~~~~

node_modules/vscode-languageclient/lib/common/protocolConverter.d.ts:118:54 - error TS2694: Namespace '"vscode"' has no exported member 'SemanticTokens'.

118     asSemanticTokens(value: ls.SemanticTokens): code.SemanticTokens;
                                                         ~~~~~~~~~~~~~~

node_modules/vscode-languageclient/lib/common/protocolConverter.d.ts:120:73 - error TS2694: Namespace '"vscode"' has no exported member 'SemanticTokens'.

120     asSemanticTokens(value: ls.SemanticTokens | undefined | null): code.SemanticTokens | undefined;
                                                                            ~~~~~~~~~~~~~~

node_modules/vscode-languageclient/lib/common/protocolConverter.d.ts:121:73 - error TS2694: Namespace '"vscode"' has no exported member 'SemanticTokens'.

121     asSemanticTokens(value: ls.SemanticTokens | undefined | null): code.SemanticTokens | undefined;
                                                                            ~~~~~~~~~~~~~~
```

I couldn't even find vscode documentation that shows or explains the changes. The example vscode extension still uses names that the ekam extension does... lame.