### PR TITLE
Allow passing in additional arguments to NM (e.g. to specify path to LLVM plugin for LTO files)

### DIFF
--- a/src/ekam/rules/compile.ekam-rule
+++ b/src/ekam/rules/compile.ekam-rule
@@ -156,9 +156,13 @@ echo newOutput "${MODULE_NAME}.o.deps"
 read DEPFILE
 
 # Generate the symbol list.
+
+# Additional flags to NM may be provided via NMFLAGS environment variables.
+# NMFLAGS is intentionally unquoted so that multiple arguments may be passed in.
+
 # TODO:  Would be nice to use nm -C here to demangle names but it doesn't appear
 #   to be supported on OSX.
-nm "$OUTPUT_DISK_PATH" > $SYMFILE
+nm $NMFLAGS "$OUTPUT_DISK_PATH" > $SYMFILE
 
 # Function which reads the symbol list on stdin and writes all symbols matching
 # the given type pattern to stdout, optionally with a prefix.


### PR DESCRIPTION
When building with LTO you need to use the LLVMGold plugin that matches
the version of Clang that's generating the LTO. Should be "safe" in
terms of not breaking any systems where this isn't available, but may
not enable LTO on all platforms (e.g. if the relative path between clang
and LLVMGold.so isn't "bin/../lib/LLVMGold.so").