### PR TITLE
Ccache support

### DIFF
--- a/src/ekam/rules/compile.ekam-rule
+++ b/src/ekam/rules/compile.ekam-rule
@@ -125,7 +125,7 @@ compile() {
   # The DYLD_ vars are the Mac OSX equivalent of LD_PRELOAD.  We don't bother checking which OS
   # we're on since the other vars will just be ignored anyway.
   LD_PRELOAD=$INTERCEPTOR DYLD_FORCE_FLAT_NAMESPACE= DYLD_INSERT_LIBRARIES=$INTERCEPTOR \
-      $TARGET_CXX -I/ekam-provider/c++header $FLAGS "$@" -c "/ekam-provider/canonical/$INPUT" \
+      ${CXX_WRAPPER:-} $TARGET_CXX -I/ekam-provider/c++header $FLAGS "$@" -c "/ekam-provider/canonical/$INPUT" \
       -o "${MODULE_NAME}${SUFFIX}" 3>&1 4<&0 >&2
 }
 

--- a/src/ekam/rules/intercept.c
+++ b/src/ekam/rules/intercept.c
@@ -682,6 +682,7 @@ int ___lxstat64 (int ver, const char* path, struct stat64* sb) {
  * treatment just like `__lxstat()` above. */
 
 WRAP(int, stat, (const char* path, struct stat* sb), (path, sb), READ, -1)
+WRAP(int, stat64, (const char* path, struct stat64* sb), (path, sb), READ, -1)
 //WRAP(int, lstat, (const char* path, struct stat* sb), (path, sb), READ, -1)
 
 typedef int lstat_t (const char* path, struct stat* sb);


### PR DESCRIPTION
There's a few things that were needed here.

* EKAM_BYPASS_DIRS - colon-separated list of directories that can be supplied that Ekam treats as passthrough. Needed for the ccache directory.
* Support for treating `/var/run<UID>` as a temporary directory. Could be worked around with ccache environment variables, but since this is a systemd convention, I figured it makes more sense as a part of ekam.
* Add wrapper for stat64. Not sure why this wasn't causing problems before but ccache was tripping up on it.
* Strip off compiler wrappers when linking (otherwise the executable path is nonsense).