### PR TITLE
Don't cause deadlock in TCMalloc

### DIFF
--- a/src/ekam/rules/intercept.c
+++ b/src/ekam/rules/intercept.c
@@ -762,6 +762,32 @@ static int intercepted_open(const char * pathname, int flags, va_list args) {
   char buffer[PATH_MAX];
   const char* remapped;
 
+#if __linux__
+  // The new TCMalloc will attempt to open various files in /sys/ to read information about the CPU
+  // (this is implemented within Abseil). If we actually do the dlsym below, we'll end up causing
+  // a deadlock within TCMalloc because `dlsym` will cause TCMalloc's constructor to try to
+  // initialize again, but the open call is being done within that. I thought perhaps this could be
+  // resolved upstream (https://github.com/google/tcmalloc/issues/78) but after looking into it
+  // more, there's a fundamental issue with calls to open these files causing trying to read these
+  // files again. Since Abseil has "call_once" semantics to read the files in /sys/, even if you
+  // tried to pre-cache it in TCMalloc, Abseil would end up deadlocking when you reentrantly tried
+  // to initialize the CPU frequency.
+  // Technically this only needs to be done if `real_open` isn't resolved, but my thought was that
+  // there's no real use-case where Ekam would want to intercept /sys/ & thus this simplifies me
+  // having to do more thorough testing.
+  if (strncmp("/sys/", pathname, strlen("/sys/")) == 0) {
+    mode_t mode = 0;
+    if (flags & O_CREAT) {
+      mode = va_arg(args, int);
+    }
+
+    if (EKAM_DEBUG) {
+      fprintf(stderr, "TCMalloc workaround. Bypassing Ekam for %s\n", pathname);
+    }
+    return syscall(SYS_openat, AT_FDCWD, pathname, flags, mode);
+  }
+#endif
+
   if (real_open == NULL) {
     real_open = (open_t*) dlsym(RTLD_NEXT, "open");
     assert(real_open != NULL);


### PR DESCRIPTION
The new TCMalloc relies on Abseil & one of the things it does is open
files in /sys/ holding a critical section. Our dlsym to find glibc's
open then causes another invocation of TCMalloc initialization which
causes a deadlock. Neither party is blameless here as both intercepting
`/sys/` is unneeded for Ekam & TCMalloc doing I/O while holding a
critical section is also unfortunate.

TCMalloc issue: https://github.com/google/tcmalloc/issues/78