### PR TITLE
Revert intercepter

### DIFF
--- a/src/ekam/rules/intercept.c
+++ b/src/ekam/rules/intercept.c
@@ -171,42 +171,6 @@ static pthread_once_t init_once_control = PTHREAD_ONCE_INIT;
 typedef ssize_t readlink_t(const char *path, char *buf, size_t bufsiz);
 static readlink_t* real_readlink = NULL;
 
-static bool bypass_interceptor = false;
-
-static void init_bypass_interceptor() {
-  static const char* sanitizer_env_vars[] = {
-    "ASAN_SYMBOLIZER_PATH",
-    "MSAN_SYMBOLIZER_PATH",
-    "LLVM_SYMBOLIZER_PATH",
-    NULL,
-  };
-
-  char real_exe[PATH_MAX + 1];
-  bool real_exe_initialized = false;
-
-  assert(real_readlink != NULL);
-
-  for (size_t i; sanitizer_env_vars[i]; i++) {
-    const char* sanitizer_path = getenv(sanitizer_env_vars[i]);
-    if (sanitizer_path != NULL) {
-      if (!real_exe_initialized) {
-        ssize_t result = real_readlink("/proc/self/exe", real_exe, PATH_MAX);
-        if (result == -1) {
-          fprintf(stderr, "Failed to readlink(/proc/self/exe): %s (%d)\n", strerror(errno), errno);
-          abort();
-        }
-
-        real_exe_initialized = true;
-      }
-
-      if (strcmp(real_exe, sanitizer_path) == 0) {
-        bypass_interceptor = true;
-        break;
-      }
-    }
-  }
-}
-
 static void init_streams_once() {
   assert(ekam_call_stream == NULL);
   assert(ekam_return_stream == NULL);
@@ -214,13 +178,6 @@ static void init_streams_once() {
   assert(real_readlink == NULL);
   real_readlink = (readlink_t*) dlsym(RTLD_NEXT, "readlink");
   assert(real_readlink != NULL);
-
-  init_bypass_interceptor();
-
-  if (bypass_interceptor) {
-    /* Bypass any further initialization as it will fail. */
-    return;
-  }
 
   ekam_call_stream = fdopen(EKAM_CALL_FILENO, "w");
   if (ekam_call_stream == NULL) {
@@ -457,11 +414,6 @@ static const char* remap_file(const char* syscall_name, const char* pathname,
   }
 
   init_streams();
-
-  if (bypass_interceptor) {
-    if (debug) fprintf(stderr, "Bypassing interceptor for %s on %s\n", syscall_name, pathname);
-    return pathname;
-  }
 
   if (strlen(pathname) >= PATH_MAX) {
     /* Too long. */

--- a/src/ekam/rules/intercept.c
+++ b/src/ekam/rules/intercept.c
@@ -107,9 +107,6 @@ int fake_pthread_once(pthread_once_t* once_control, void (*init_func)(void)) {
   int initialized = __atomic_load_n(once_control, __ATOMIC_ACQUIRE);
   if (likely(initialized & ONCE_DONE)) return 0;
 
-  // TODO(soon): Remove the dynamic_pthread_mutex usage once dynamic_pthread_once isn't forced to
-  // unconditionally use fake_pthread_once. See init_pthreads.
-
   // The real implementation is typically more complex to try to make sure that concurrent
   // initialization of different pthread_once doesn't have a false dependency on a global mutex.
   // However, we only have a single such usage here & that would be overkill to try to implement on
@@ -139,10 +136,6 @@ void init_pthreads() {
         (pthread_once_func*) dlsym(RTLD_DEFAULT, "pthread_once");
   }
   /* TODO:  For some reason the pthread_once returned by dlsym() doesn't do anything? */
-  // Update 7/13/2021 - on Arch Linux pthread_once seems to work fine. Not tested on Buster so
-  // unclear if this was a glibc bug that had been fixed at some point or there's something subtle
-  // about when this breaks. There's an assert added in init_streams that ensures the functor
-  // invoked.
   if (dynamic_pthread_once == NULL || 1) {
     dynamic_pthread_once = &fake_pthread_once;
   }
@@ -215,12 +208,6 @@ static void init_bypass_interceptor() {
 }
 
 static void init_streams_once() {
-  static bool initialized = false;
-  if (__atomic_exchange_n(&initialized, true, __ATOMIC_RELEASE)) {
-    fprintf(stderr, "pthread_once is broken\n");
-    abort();
-  }
-
   assert(ekam_call_stream == NULL);
   assert(ekam_return_stream == NULL);
 
@@ -256,8 +243,6 @@ static void init_streams_once() {
 static void init_streams() {
   init_pthreads();
   dynamic_pthread_once(&init_once_control, &init_streams_once);
-  // This assert makes sure the pthread_once call actually invokes the initializer.
-  assert(bypass_interceptor || (ekam_call_stream != NULL && ekam_return_stream != NULL));
 }
 
 /****************************************************************************************/

--- a/src/ekam/rules/intercept.c
+++ b/src/ekam/rules/intercept.c
@@ -41,8 +41,6 @@
 
 static const int EKAM_DEBUG = 0;
 
-#define likely(x)       __builtin_expect((x),1)
-
 typedef int open_t(const char * pathname, int flags, ...);
 void __attribute__((constructor)) start_interceptor() {
   if (EKAM_DEBUG) {
@@ -100,31 +98,7 @@ static pthread_mutex_lock_func* dynamic_pthread_mutex_lock = NULL;
 static pthread_mutex_unlock_func* dynamic_pthread_mutex_unlock = NULL;
 
 int fake_pthread_once(pthread_once_t* once_control, void (*init_func)(void)) {
-  static pthread_mutex_t fake_once_mutex = PTHREAD_MUTEX_INITIALIZER;
-  static int ONCE_INPROGRESS = 1;
-  static int ONCE_DONE = 2;
-
-  int initialized = __atomic_load_n(once_control, __ATOMIC_ACQUIRE);
-  if (likely(initialized & ONCE_DONE)) return 0;
-
-  // The real implementation is typically more complex to try to make sure that concurrent
-  // initialization of different pthread_once doesn't have a false dependency on a global mutex.
-  // However, we only have a single such usage here & that would be overkill to try to implement on
-  // MacOS and Linux. Use a single mutex anyway because it would have largely the same effect. It
-  // also has additional complexities to handle things like forking and that too isn't a concern
-  // here.
-  dynamic_pthread_mutex_lock(&fake_once_mutex);
-  pthread_once_t expected = PTHREAD_ONCE_INIT;
-  bool updated =__atomic_compare_exchange_n(once_control, &expected, ONCE_INPROGRESS, false,
-      __ATOMIC_RELEASE, __ATOMIC_RELAXED);
-  if (likely(!updated)) {
-    assert(__atomic_load_n(&expected, __ATOMIC_RELAXED) == ONCE_DONE);
-    dynamic_pthread_mutex_unlock(&fake_once_mutex);
-    return 0;
-  }
   init_func();
-  __atomic_store_n(once_control, ONCE_DONE, __ATOMIC_RELEASE);
-  dynamic_pthread_mutex_unlock(&fake_once_mutex);
   return 0;
 }
 int fake_pthread_mutex_lock(pthread_mutex_t* mutex) { return 0; }


### PR DESCRIPTION
This reverts #48.

The interceptor changes caused `capnp` to segfault at startup. Building Ekam itself did not work with these changes.

cc @vlovich