### PR TITLE
Fix intermittent abort running Ekam in continuous

### DIFF
--- a/src/os/EpollEventManager.cpp
+++ b/src/os/EpollEventManager.cpp
@@ -521,8 +521,9 @@ public:
     if (wd >= 0) {
       DEBUG_INFO << "inotify_rm_watch(" << path << ") [" << wd << "]";
 
-      if (WRAP_SYSCALL(inotify_rm_watch, *inotifyHandler->inotifyStream.getHandle(), wd) < 0) {
-        DEBUG_ERROR << "inotify_rm_watch(" << path << "): " << strerror(errno);
+      if (inotify_rm_watch(*inotifyHandler->inotifyStream.getHandle(), wd) < 0) {
+        DEBUG_ERROR << "inotify_rm_watch(" << path << ") on (" <<
+            *inotifyHandler->inotifyStream.getHandle() << ", " wd << "): " << strerror(errno);
       }
     }
 


### PR DESCRIPTION
```
ekam debug: ERROR: /ekam-provider/canonical/ekam/Driver.cpp:597: Tried to remove source file that wasn't ever added: edgeworker/tests/alarm.ew-test-bin.c++
terminate called after throwing an instance of 'ekam::OsError'
  what():  inotify_rm_watch(inotify): Invalid argument
make: *** [Makefile:360: continuous] Aborted (core dumped)
```