### PR TITLE
Implement ekam-client -f

### DIFF
--- a/src/ekam/ConsoleDashboard.cpp
+++ b/src/ekam/ConsoleDashboard.cpp
@@ -232,16 +232,22 @@ void ConsoleDashboard::TaskImpl::setState(TaskState state) {
       if (silence != SILENT) dashboard->runningTasks.push_back(this);
       break;
     case DONE:
-      writeFinalLog(DONE_COLOR, " ");
+      if (!dashboard->onlyPrintFailures) {
+        writeFinalLog(DONE_COLOR, " ");
+      }
       break;
     case PASSED:
-      writeFinalLog(PASSED_COLOR, "✔");
+      if (!dashboard->onlyPrintFailures) {
+        writeFinalLog(PASSED_COLOR, "✔");
+      }
       break;
     case FAILED:
       writeFinalLog(FAILED_COLOR, "✘");
       break;
     case BLOCKED:
-      // Don't display.
+      if (dashboard->onlyPrintFailures) {
+        writeFinalLog(BLOCKED_COLOR, "✘?");
+      }
       break;
   }
 
@@ -320,11 +326,13 @@ const char* const ConsoleDashboard::ANSI_CLEAR_BELOW_CURSOR = "\033[0J";
 const ConsoleDashboard::Color ConsoleDashboard::DONE_COLOR = BRIGHT_BLUE;
 const ConsoleDashboard::Color ConsoleDashboard::PASSED_COLOR = BRIGHT_GREEN;
 const ConsoleDashboard::Color ConsoleDashboard::FAILED_COLOR = BRIGHT_RED;
+const ConsoleDashboard::Color ConsoleDashboard::BLOCKED_COLOR = RED;
 const ConsoleDashboard::Color ConsoleDashboard::RUNNING_COLOR = BRIGHT_FUCHSIA;
 
-ConsoleDashboard::ConsoleDashboard(FILE* output, int maxDisplayedLogLines)
+ConsoleDashboard::ConsoleDashboard(FILE* output, int maxDisplayedLogLines, bool onlyPrintFailures)
     : fd(fileno(output)), out(output), maxDisplayedLogLines(maxDisplayedLogLines),
-      runningTasksLineCount(0), lastDebugMessageCount(DebugMessage::getMessageCount()) {}
+      onlyPrintFailures(onlyPrintFailures), runningTasksLineCount(0),
+      lastDebugMessageCount(DebugMessage::getMessageCount()) {}
 ConsoleDashboard::~ConsoleDashboard() {}
 
 OwnedPtr<Dashboard::Task> ConsoleDashboard::beginTask(

--- a/src/ekam/ConsoleDashboard.h
+++ b/src/ekam/ConsoleDashboard.h
@@ -25,7 +25,7 @@ namespace ekam {
 
 class ConsoleDashboard : public Dashboard {
 public:
-  ConsoleDashboard(FILE* output, int maxDisplayedLogLines);
+  ConsoleDashboard(FILE* output, int maxDisplayedLogLines, bool onlyPrintFailures = false);
   ~ConsoleDashboard();
 
   // implements Dashboard ----------------------------------------------------------------
@@ -38,6 +38,7 @@ private:
   int fd;
   FILE* out;
   int maxDisplayedLogLines;
+  bool onlyPrintFailures;
 
   std::vector<TaskImpl*> runningTasks;
   int runningTasksLineCount;
@@ -71,6 +72,7 @@ private:
   static const Color PASSED_COLOR;
   static const Color FAILED_COLOR;
   static const Color RUNNING_COLOR;
+  static const Color BLOCKED_COLOR;
 
   void clearRunning();
   void drawRunning();

--- a/src/ekam/ekam-client.cpp
+++ b/src/ekam/ekam-client.cpp
@@ -80,7 +80,8 @@ Dashboard::TaskState toDashboardState(proto::TaskUpdate::State state) {
 
 int main(int argc, char* argv[]) {
   int maxDisplayedLogLines = 30;
-  
+  bool onlyPrintFailures = false;
+
   for (int i = 1; i < argc; i++) {
     if (strcmp(argv[i], "-l") == 0) {
       char* endptr;
@@ -89,6 +90,8 @@ int main(int argc, char* argv[]) {
         fprintf(stderr, "Expected number after -l.\n");
         return 1;
       }
+    } else if (strcmp(argv[i], "-f") == 0) {
+      onlyPrintFailures = true;
     } else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
       printf(
           "usage: nc <host> <port> | %s [-l <count>]\n"
@@ -96,6 +99,10 @@ int main(int argc, char* argv[]) {
           "Connect to Ekam process at <host> <port> and display build status.\n"
           "\n"
           "options:\n"
+          "  -f            Only print failures, and print failures early. Some failures\n"
+          "                will be due to missing dependencies, and will be marked using\n"
+          "                with ✘? and a darker shade of red.\n"
+          "\n"
           "  -l <count>    Set max number of log lines to display per action. This is\n"
           "                kept relatively short by default because it makes the build\n"
           "                output noisy, but you may need to increase it if you need\n"
@@ -117,7 +124,7 @@ int main(int argc, char* argv[]) {
     printf("Project root: %s\n", header.getProjectRoot().cStr());
   }
 
-  ConsoleDashboard dashboard(stdout, maxDisplayedLogLines);
+  ConsoleDashboard dashboard(stdout, maxDisplayedLogLines, onlyPrintFailures);
   OwnedPtrMap<int, Dashboard::Task> tasks;
 
   while (bufferedInput.tryGetReadBuffer() != nullptr) {


### PR DESCRIPTION
This mode prints only failures, and prints failures when they happen
(meaning even when ekam is not sure if they are a true failure or caused
by a missing dependency.) This is noisy as there are a lot of "false"
errors, but is an easy way to get *much* quicker feedback when iterating
on headers that are included in lots of places, where before this you'd
otherwise have to wait for the entire build to settle before seeing errors.