### PR TITLE
libfuzzer support

### DIFF
--- a/src/ekam/CppActionFactory.h
+++ b/src/ekam/CppActionFactory.h
@@ -34,6 +34,7 @@ public:
 
 private:
   static const Tag MAIN_SYMBOLS[];
+  static const Tag LIBFUZZER_SYMBOL;
   static const Tag GTEST_TEST;
   static const Tag KJTEST_TEST;
   static const Tag NODEJS_MODULE;


### PR DESCRIPTION
The feature is enabled by EKAM_LIBFUZZER_ENABLE environment variable present.

Whenever an object file exports LLVMFuzzerTestOneInput it will be linked
with -fsanitize=fuzzer argument. The argument can be overriden by
EKAM_LIBFUZZER_LINKER_ARG environment variable.