### PR TITLE
Bump typescript version

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -26,7 +26,7 @@
         "vscode-languageserver": "6.x"
     },
     "devDependencies": {
-        "typescript": "^3.8.3",
+        "typescript": "^4.9.4",
         "@types/vscode": "^1.1.0",
         "@types/node": "^6.0.40",
         "vsce": "^1.51.0"


### PR DESCRIPTION
This extension doesn't build anymore due to changes in the vscode types, so this PR bumps the typescript version to allow the extension to compile
